### PR TITLE
Set up a homebrew tap redirect from the kubefirst github org to the konstructio org

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,0 +1,3 @@
+{
+  kubefirst: "konstructio"
+}

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,3 @@
 {
-  kubefirst: "konstructio"
+  "kubefirst": "konstructio"
 }

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,3 @@
 {
-  "kubefirst": "konstructio"
+  "kubefirst": "konstructio/kubefirst"
 }

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,3 @@
 {
-  "kubefirst": "konstructio/kubefirst"
+  "kubefirst": "konstructio/taps"
 }


### PR DESCRIPTION
## Description
This PR adds a homebrew tap_migrations.json file to redirect homebrew to use konstructio/taps from kubefirst/taps. See more details at https://stackoverflow.com/questions/70079331/best-way-to-deprecate-a-homebrew-tap-to-transition-to-another-tap and https://docs.brew.sh/Migrating-A-Formula-To-A-Tap

## Related Issue(s)
Fixes issue #5 

## How to test

1. Run `brew uninstall kubefirst`
2. Run `brew install MikeStankavich/taps/kubefirst`
3. Confirm that the install gets redirected to konstructio/taps/kubefirst and installs the latest version

Example:
``` 
> brew uninstall kubefirst
Uninstalling /opt/homebrew/Cellar/kubefirst/2.7.9... (6 files, 117.4MB)

> brew install kubefirst/tools/kubefirst
==> Fetching kubefirst/tools/kubefirst
==> Downloading https://github.com/kubefirst/kubefirst/releases/download/v2.4.17/kubefirst_2.4.17_darwin_arm64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/332999480/79108c7b-14b
################################################################################################################# 100.0%
==> Installing kubefirst from kubefirst/tools
🍺  /opt/homebrew/Cellar/kubefirst/2.4.17: 6 files, 124.0MB, built in 1 second
==> Running `brew cleanup kubefirst`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/mike/Library/Caches/Homebrew/kubefirst--2.7.9.tar.gz... (43.9MB)

> brew install MikeStankavich/taps/kubefirst
kubefirst 2.4.17 is already installed but outdated (so it will be upgraded).
==> Fetching konstructio/taps/kubefirst
==> Downloading https://github.com/konstructio/kubefirst/releases/download/v2.7.9/kubefirst_2.7.9_darwin_arm64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/332999480/512c93be-138
################################################################################################################# 100.0%
==> Upgrading konstructio/taps/kubefirst
  2.4.17 -> 2.7.9
🍺  /opt/homebrew/Cellar/kubefirst/2.7.9: 6 files, 117.4MB, built in 2 seconds
==> Running `brew cleanup kubefirst`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /opt/homebrew/Cellar/kubefirst/2.4.17... (6 files, 124.0MB)
Removing: /Users/mike/Library/Caches/Homebrew/kubefirst--2.4.17.tar.gz... (43.1MB)
```